### PR TITLE
Fix formatting issue in startup log message

### DIFF
--- a/cmd/vouch/main.go
+++ b/cmd/vouch/main.go
@@ -141,7 +141,7 @@ func run(f *flags) error {
 	go func() {
 		log.Info("starting server",
 			"listen", cfg.Proxy.Listen,
-			"target", cfg.Proxy.Target,
+			"target", cfg.Proxy.Target.String(),
 		)
 		errch <- srv.Start(cfg.Proxy.Listen)
 	}()

--- a/cmd/vouch/main.go
+++ b/cmd/vouch/main.go
@@ -137,13 +137,13 @@ func run(f *flags) error {
 	)
 
 	// Run the server and handle termination signals for graceful shutdown.
-	errch := make(chan error, 1)
+	errCh := make(chan error, 1)
 	go func() {
 		log.Info("starting server",
 			"listen", cfg.Proxy.Listen,
 			"target", cfg.Proxy.Target.String(),
 		)
-		errch <- srv.Start(cfg.Proxy.Listen)
+		errCh <- srv.Start(cfg.Proxy.Listen)
 	}()
 
 	ctx, stop := signal.NotifyContext(
@@ -154,7 +154,7 @@ func run(f *flags) error {
 	defer stop()
 
 	select {
-	case err := <-errch:
+	case err := <-errCh:
 		// Ensure background work is stopped if the server exits.
 		appCancel()
 		if err != nil {
@@ -168,7 +168,7 @@ func run(f *flags) error {
 		if err := srv.Shutdown(context.Background()); err != nil && !errors.Is(err, context.Canceled) {
 			log.Error("graceful shutdown failed", "error", err)
 		}
-		<-errch // Wait for server to stop.
+		<-errCh // Wait for server to stop.
 		log.Info("server stopped")
 	}
 	return nil

--- a/internal/server/server_test.go
+++ b/internal/server/server_test.go
@@ -156,9 +156,9 @@ func TestServerStartAndShutdown(t *testing.T) {
 
 	s := New(u)
 
-	errch := make(chan error, 1)
+	errCh := make(chan error, 1)
 	go func() {
-		errch <- s.Start(addr)
+		errCh <- s.Start(addr)
 	}()
 
 	// Wait until server responds (with timeout).
@@ -183,7 +183,7 @@ func TestServerStartAndShutdown(t *testing.T) {
 	require.NoError(t, s.Shutdown(ctx))
 
 	// Start must return nil on graceful shutdown.
-	require.NoError(t, <-errch)
+	require.NoError(t, <-errCh)
 }
 
 func TestServerStartPortInUse(t *testing.T) {
@@ -205,19 +205,19 @@ func TestServerStartPortInUse(t *testing.T) {
 
 	s := New(u)
 
-	errch := make(chan error, 1)
+	errCh := make(chan error, 1)
 	go func() {
-		errch <- s.Start(addr)
+		errCh <- s.Start(addr)
 	}()
 
 	// Expect an error (address already in use) shortly.
 	select {
-	case e := <-errch:
+	case e := <-errCh:
 		require.Error(t, e)
 	default:
 		// Allow a little time if not immediate.
 		select {
-		case e := <-errch:
+		case e := <-errCh:
 			require.Error(t, e)
 		case <-time.After(500 * time.Millisecond):
 			t.Fatal("expected Start to fail due to port already in use")


### PR DESCRIPTION
Convert the proxy target URL into a string for logging.