### PR TITLE
Restructure configuration

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -34,7 +34,7 @@ jobs:
         run: go vet ./...
       - name: Execute tests
         run: |
-          go test -v ./... -covermode=count -coverprofile=coverage.out
+          go test -v -race -cover -covermode=atomic -coverprofile=coverage.out ./...
           go tool cover -func=coverage.out -o=coverage.out
       - name: Go Coverage Badge
         uses: tj-actions/coverage-badge-go@v3

--- a/cmd/vouch/main.go
+++ b/cmd/vouch/main.go
@@ -109,7 +109,7 @@ func run(f *flags) error {
 	log.Info("loading config", "path", f.path)
 
 	// Load and validate the configuration.
-	cfg, ws, err := config.Load(f.path)
+	cfg, ws, err := config.Load(f.path, config.WithVersion(version))
 	for _, w := range ws {
 		log.Warn(w)
 	}

--- a/cmd/vouch/main_test.go
+++ b/cmd/vouch/main_test.go
@@ -37,12 +37,13 @@ func writeConfig(t *testing.T) string {
 	require.NoError(t, os.WriteFile(jwksPath, []byte(jwks), 0o600))
 
 	cfg := fmt.Sprintf(`
-token:
-  keys:
-    static: %q
-rules:
-  - mode: allow
-    when: "true"
+guard:
+  token:
+    keys:
+      static: %q
+  rules:
+    - mode: allow
+      when: "true"
 `, jwksPath)
 	path := filepath.Join(dir, "config.yaml")
 	require.NoError(t, os.WriteFile(path, []byte(cfg), 0o600))

--- a/config.schema.json
+++ b/config.schema.json
@@ -2,72 +2,69 @@
   "$schema": "http://json-schema.org/draft-07/schema#",
   "$id": "https://raw.githubusercontent.com/deep-rent/vouch/main/config.schema.json",
   "title": "Vouch Configuration",
-  "description": "Schema for the Vouch configuration file.",
   "type": "object",
   "properties": {
+    "local": {
+      "$ref": "#/definitions/Local"
+    },
     "proxy": {
       "$ref": "#/definitions/Proxy"
     },
-    "token": {
-      "$ref": "#/definitions/Token"
-    },
-    "rules": {
-      "description": "An ordered list of authorization rules. The first matching rule decides the outcome.",
-      "type": "array",
-      "items": {
-        "$ref": "#/definitions/Rule"
-      },
-      "minItems": 1
+    "guard": {
+      "$ref": "#/definitions/Guard"
     }
   },
   "required": [
-    "token",
-    "rules"
+    "guard"
   ],
   "additionalProperties": false,
   "definitions": {
-    "Proxy": {
+    "Local": {
       "type": "object",
-      "description": "Configures the local HTTP server and reverse proxy behavior.",
+      "description": "Configures the local HTTP server.",
       "properties": {
-        "listen": {
+        "host": {
           "type": "string",
-          "description": "The TCP address the server listens on, in the form 'host:port' or ':port' to listen on all interfaces.",
-          "default": ":8080"
+          "description": "Hostname or IP to bind to.",
+          "default": ""
         },
-        "target": {
-          "type": "string",
-          "description": "The CouchDB URL to which requests are proxied.",
-          "default": "http://localhost:5984",
-          "format": "uri"
-        },
-        "headers": {
-          "$ref": "#/definitions/Headers"
+        "port": {
+          "type": "integer",
+          "description": "TCP port to listen on. 0 will be mapped to 8080.",
+          "default": 8080,
+          "minimum": 0,
+          "maximum": 65535
         }
       },
       "additionalProperties": false
     },
-    "Signer": {
+    "Proxy": {
       "type": "object",
-      "description": "Configures signing of CouchDB proxy authentication tokens.",
+      "description": "Configures the upstream CouchDB target and proxy headers.",
       "properties": {
-        "secret": {
+        "scheme": {
           "type": "string",
-          "description": "The CouchDB proxy secret used to sign the token header. If empty, the token header will be omitted from forwarded requests.",
-          "minLength": 32,
-          "default": ""
-        },
-        "algorithm": {
-          "type": "string",
-          "description": "The hash algorithm used to protect the token.",
           "enum": [
-            "sha",
-            "sha224",
-            "sha256",
-            "sha384",
-            "sha512"
+            "http",
+            "https"
           ],
-          "default": "sha256"
+          "default": "http",
+          "description": "Upstream URL scheme."
+        },
+        "host": {
+          "type": "string",
+          "default": "localhost",
+          "description": "Upstream hostname or IP address."
+        },
+        "port": {
+          "type": "integer",
+          "default": 5984,
+          "minimum": 0,
+          "maximum": 65535,
+          "description": "Upstream TCP port. 0 will be mapped to 5984."
+        },
+        "headers": {
+          "$ref": "#/definitions/Headers"
         }
       },
       "additionalProperties": false
@@ -76,50 +73,125 @@
       "type": "object",
       "description": "Customizes the proxy headers sent to CouchDB.",
       "properties": {
-        "signer": {
-          "$ref": "#/definitions/Signer"
-        },
         "user": {
-          "type": "string",
-          "description": "The proxy header name that carries the CouchDB user name.",
-          "default": "X-Auth-CouchDB-UserName"
+          "$ref": "#/definitions/UserHeader"
         },
         "roles": {
-          "type": "string",
-          "description": "The proxy header name that carries comma-separated roles.",
-          "default": "X-Auth-CouchDB-Roles"
+          "$ref": "#/definitions/RolesHeader"
         },
         "token": {
+          "$ref": "#/definitions/TokenHeader"
+        }
+      },
+      "additionalProperties": false
+    },
+    "UserHeader": {
+      "type": "object",
+      "description": "Configures the proxy user header.",
+      "properties": {
+        "name": {
           "type": "string",
-          "description": "The proxy header name that carries the signed token.",
-          "default": "X-Auth-CouchDB-Token"
+          "description": "Header name carrying the CouchDB user.",
+          "default": "X-Auth-CouchDB-UserName"
         },
         "anonymous": {
           "type": "boolean",
-          "description": "Allows forwarding requests without an authenticated user.",
+          "description": "Allow forwarding anonymous requests (matching allow rule does not set user).",
           "default": false
         }
       },
       "additionalProperties": false
     },
+    "RolesHeader": {
+      "type": "object",
+      "description": "Configures the proxy roles header.",
+      "properties": {
+        "name": {
+          "type": "string",
+          "description": "Header name carrying comma-separated roles.",
+          "default": "X-Auth-CouchDB-Roles"
+        },
+        "default": {
+          "type": "array",
+          "description": "Default roles when the matching allow rule does not set roles.",
+          "items": {
+            "type": "string"
+          },
+          "default": []
+        }
+      },
+      "additionalProperties": false
+    },
+    "TokenHeader": {
+      "type": "object",
+      "description": "Configures the proxy token header used to secure the communication between Vouch and CouchDB.",
+      "properties": {
+        "name": {
+          "type": "string",
+          "description": "Header name carrying the signed token.",
+          "default": "X-Auth-CouchDB-Token"
+        },
+        "secret": {
+          "type": "string",
+          "description": "Shared secret used to sign the token header. If omitted or empty, the header will not be sent.",
+          "default": "",
+          "minLength": 32
+        },
+        "algorithm": {
+          "type": "string",
+          "description": "Hash algorithm for token signing.",
+          "enum": [
+            "",
+            "sha",
+            "sha224",
+            "sha256",
+            "sha384",
+            "sha512"
+          ],
+          "default": ""
+        }
+      },
+      "additionalProperties": false
+    },
+    "Guard": {
+      "type": "object",
+      "description": "Configures authentication and authorization.",
+      "properties": {
+        "token": {
+          "$ref": "#/definitions/Token"
+        },
+        "rules": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/Rule"
+          },
+          "minItems": 1
+        }
+      },
+      "required": [
+        "token",
+        "rules"
+      ],
+      "additionalProperties": false
+    },
     "Token": {
       "type": "object",
-      "description": "Configures how incoming bearer tokens are validated.",
+      "description": "Configures how incoming JWTs are validated.",
       "properties": {
         "keys": {
           "$ref": "#/definitions/Keys"
         },
         "issuer": {
           "type": "string",
-          "description": "The expected value of the 'iss' claim. If omitted, the issuer is not validated."
+          "description": "Expected value of the 'iss' claim (optional)."
         },
         "audience": {
           "type": "string",
-          "description": "The value that the 'aud' claim is expected to contain. If omitted, the audience is not validated."
+          "description": "Expected value of the 'aud' claim (optional)."
         },
         "leeway": {
           "type": "integer",
-          "description": "The allowed clock skew interpreted as seconds. Concerns validation of the 'exp', 'nbf', and 'iat' claims.",
+          "description": "Allowed clock skew in seconds. Concerns 'exp' and 'nbf' claims.",
           "default": 0,
           "minimum": 0
         }
@@ -131,11 +203,11 @@
     },
     "Keys": {
       "type": "object",
-      "description": "Configures sources of JWK material used to verify token signatures.",
+      "description": "Sources of JWK material used to verify token signatures.",
       "properties": {
         "static": {
           "type": "string",
-          "description": "A filesystem path to a JWKS document."
+          "description": "Filesystem path to a JWKS document."
         },
         "remote": {
           "$ref": "#/definitions/Remote"
@@ -157,18 +229,18 @@
     },
     "Remote": {
       "type": "object",
-      "description": "Configures periodic retrieval of a JWKS from a remote endpoint.",
+      "description": "Periodic retrieval of a JWKS from a remote endpoint.",
       "properties": {
         "endpoint": {
           "type": "string",
-          "description": "The HTTPS URL from which the JWKS is retrieved.",
+          "description": "HTTP(S) URL from which the JWKS is retrieved.",
           "format": "uri"
         },
         "interval": {
           "type": "integer",
-          "description": "The poll interval measured in minutes.",
+          "description": "Poll interval in minutes. 0 will be mapped to 30.",
           "default": 30,
-          "minimum": 1
+          "minimum": 0
         }
       },
       "required": [
@@ -182,7 +254,6 @@
       "properties": {
         "mode": {
           "type": "string",
-          "description": "Selects the decision when the rule matches.",
           "enum": [
             "allow",
             "deny"
@@ -190,22 +261,66 @@
         },
         "when": {
           "type": "string",
-          "description": "The condition under which the rule applies. Must evaluate to a boolean."
+          "description": "Condition under which the rule applies (must evaluate to boolean)."
         },
         "user": {
           "type": "string",
-          "description": "An expression that determines the CouchDB user name. Only used in 'allow' mode."
+          "description": "Expression for CouchDB user (only in 'allow' mode)."
         },
         "roles": {
           "type": "string",
-          "description": "An expression that specifies CouchDB roles. Only used in 'allow' mode."
+          "description": "Expression for CouchDB roles (only in 'allow' mode)."
         }
       },
       "required": [
         "mode",
         "when"
       ],
-      "additionalProperties": false
+      "additionalProperties": false,
+      "allOf": [
+        {
+          "if": {
+            "properties": {
+              "mode": {
+                "const": "deny"
+              }
+            }
+          },
+          "then": {
+            "not": {
+              "anyOf": [
+                {
+                  "required": [
+                    "user"
+                  ]
+                },
+                {
+                  "required": [
+                    "roles"
+                  ]
+                }
+              ]
+            }
+          }
+        },
+        {
+          "if": {
+            "required": [
+              "roles"
+            ]
+          },
+          "then": {
+            "required": [
+              "user"
+            ],
+            "properties": {
+              "mode": {
+                "const": "allow"
+              }
+            }
+          }
+        }
+      ]
     }
   }
 }

--- a/container/auth/jwks.json
+++ b/container/auth/jwks.json
@@ -1,0 +1,14 @@
+{
+  "keys": [
+    {
+      "kty": "EC",
+      "use": "sig",
+      "alg": "ES256",
+      "kid": "936e8759-5806-4244-9ad9-d3acf6369dc1",
+      "crv": "P-256",
+      "x": "Z3X1VCcMcHLJGPCdqNpEV8U8wpjZ_QOg8Q4Il9VveLE",
+      "y": "wniSNmkmxNu61lVpm0ebacvcsi2iM-u0VUXhNmS-FsE",
+      "d": "i3WOX1VK9SyMR-tM2vCMg2mNQWFxbSJvgE34DgV9rNk"
+    }
+  ]
+}

--- a/container/vouch/config.yaml
+++ b/container/vouch/config.yaml
@@ -19,14 +19,14 @@ proxy:
       algorithm: sha256
 guard:
   token:
-    # issuer: https://auth.example.com/
-    # audience: couchdb
-    # leeway: 60
+    issuer: http://auth/
+    audience: couchdb
+    leeway: 60
     keys:
       static: /app/jwks.json
-      # remote:
-      #   endpoint: https://auth.example.com/.well-known/jwks.json
-      #   interval: 60
+      remote:
+        endpoint: http://auth/.well-known/jwks.json
+        interval: 60
   rules:
     - when: 'Claim("adm") == true'
       mode: allow

--- a/container/vouch/config.yaml
+++ b/container/vouch/config.yaml
@@ -1,26 +1,34 @@
 # yaml-language-server: $schema=../../config.schema.json
+local:
+  host: ''
+  port: 8080
 proxy:
-  listen: :8080
-  target: http://couchdb:5984
+  scheme: http
+  host: localhost
+  port: 5984
   headers:
-    signer:
+    user:
+      name: X-Vouch-User
+      anonymous: false
+    roles:
+      name: X-Vouch-Roles
+      default: []
+    token:
+      name: X-Vouch-Token
       secret: qm1nf4k8ZHzwf76XFZx4TObkx8E3L5eo
       algorithm: sha256
-    user: X-Vouch-User
-    roles: X-Vouch-Roles
-    token: X-Vouch-Token
-    anonymous: false
-token:
-  # issuer: https://auth.example.com/
-  # audience: couchdb
-  # leeway: 60
-  keys:
-    static: /app/jwks.json
-    # remote:
-    #   endpoint: https://auth.example.com/.well-known/jwks.json
-    #   interval: 60
-rules:
-  - when: 'Claim("adm") == true'
-    mode: allow
-    user: 'Claim("sub") ?? ""'
-    roles: '["_admin"]'
+guard:
+  token:
+    # issuer: https://auth.example.com/
+    # audience: couchdb
+    # leeway: 60
+    keys:
+      static: /app/jwks.json
+      # remote:
+      #   endpoint: https://auth.example.com/.well-known/jwks.json
+      #   interval: 60
+  rules:
+    - when: 'Claim("adm") == true'
+      mode: allow
+      user: 'Claim("sub") ?? ""'
+      roles: '["_admin"]'

--- a/container/vouch/jwks.json
+++ b/container/vouch/jwks.json
@@ -1,16 +1,6 @@
 {
   "keys": [
     {
-      "kty": "EC",
-      "use": "sig",
-      "alg": "ES256",
-      "kid": "936e8759-5806-4244-9ad9-d3acf6369dc1",
-      "crv": "P-256",
-      "x": "Z3X1VCcMcHLJGPCdqNpEV8U8wpjZ_QOg8Q4Il9VveLE",
-      "y": "wniSNmkmxNu61lVpm0ebacvcsi2iM-u0VUXhNmS-FsE",
-      "d": "i3WOX1VK9SyMR-tM2vCMg2mNQWFxbSJvgE34DgV9rNk"
-    },
-    {
       "kty": "RSA",
       "use": "sig",
       "alg": "RS256",

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -16,6 +16,15 @@ services:
       - couchdb-data:/opt/couchdb/data
       - ./container/couchdb/local.ini:/tmp/configs/local.ini:ro
     entrypoint: /usr/local/bin/entrypoint-wrapper.sh
+
+  auth:
+    image: nginx:alpine
+    container_name: auth
+    restart: unless-stopped
+    ports:
+      - "8081:80"
+    volumes:
+      - ./container/auth:/usr/share/nginx/html/.well-known:ro
   vouch:
     build:
       context: .
@@ -24,6 +33,7 @@ services:
         - VERSION=dev
     container_name: vouch
     depends_on:
+      - auth
       - couchdb
     environment:
       VOUCH_LOG: info

--- a/internal/auth/guard.go
+++ b/internal/auth/guard.go
@@ -119,7 +119,7 @@ var (
 
 // NewGuard constructs a Guard from configuration by wiring a token parser and
 // compiling the authorization rules.
-func NewGuard(ctx context.Context, cfg config.Config) (Guard, error) {
+func NewGuard(ctx context.Context, cfg config.Guard) (Guard, error) {
 	parser, err := newParser(ctx, cfg.Token)
 	if err != nil {
 		return nil, fmt.Errorf("create parser: %w", err)

--- a/internal/auth/guard_test.go
+++ b/internal/auth/guard_test.go
@@ -134,7 +134,7 @@ func TestNewGuard(t *testing.T) {
 		newParser = func(context.Context, config.Token) (token.Parser, error) {
 			return nil, assert.AnError
 		}
-		_, err := NewGuard(context.Background(), config.Config{})
+		_, err := NewGuard(context.Background(), config.Guard{})
 		require.Error(t, err)
 		assert.Contains(t, err.Error(), "create parser")
 	})
@@ -148,7 +148,7 @@ func TestNewGuard(t *testing.T) {
 		newEngine = func([]config.Rule) (rules.Engine, error) {
 			return nil, assert.AnError
 		}
-		_, err := NewGuard(context.Background(), config.Config{})
+		_, err := NewGuard(context.Background(), config.Guard{})
 		require.Error(t, err)
 		assert.Contains(t, err.Error(), "create engine")
 	})
@@ -164,7 +164,7 @@ func TestNewGuard(t *testing.T) {
 				return rules.Result{Pass: true}, nil
 			}), nil
 		}
-		g, err := NewGuard(context.Background(), config.Config{
+		g, err := NewGuard(context.Background(), config.Guard{
 			Rules: []config.Rule{{When: "true"}},
 		})
 		require.NoError(t, err)

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -415,8 +415,8 @@ func (r rolesHeader) validate(_ *warnings) (RolesHeader, error) {
 
 // tokenHeader is the wire representation of TokenHeader.
 type tokenHeader struct {
-	Name string `yaml:"name"`
-	signer
+	Name   string `yaml:"name"`
+	signer `yaml:",inline"`
 }
 
 // validate derives the runtime representation of tokenHeader.
@@ -427,13 +427,13 @@ func (t tokenHeader) validate(w *warnings) (TokenHeader, error) {
 	} else {
 		name = http.CanonicalHeaderKey(name)
 	}
-	signer, err := t.signer.validate(w)
+	s, err := t.signer.validate(w)
 	if err != nil {
 		return TokenHeader{}, fmt.Errorf("signer.%w", err)
 	}
 	return TokenHeader{
 		Name:   name,
-		Signer: signer,
+		Signer: s,
 	}, nil
 }
 

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -22,9 +22,12 @@ import (
 	"errors"
 	"fmt"
 	"hash"
+	"net"
 	"net/http"
 	"net/url"
 	"os"
+	"sort"
+	"strconv"
 	"strings"
 	"time"
 
@@ -50,26 +53,46 @@ import (
 
 // Config represents the entire application configuration.
 type Config struct {
-	// Proxy configures the local HTTP server and reverse proxy behavior.
-	Proxy Proxy
-	// Token configures how incoming bearer tokens are validated.
-	Token Token
-	// Rules defines ordered authorization rules. The first matching rule
-	// decides the outcome. At least one rule is required.
-	Rules []Rule
+	// Guard configures authentication and authorization of incoming requests.
+	Guard Guard
+	Server
 }
 
-// SignerEnabled indicates whether or not CouchDB proxy signing is enabled.
-func (c Config) SignerEnabled() bool {
-	return c.Proxy.Headers.Signer.Secret != ""
+// warnings collects a list of non-fatal configuration issues.
+type warnings struct {
+	msgs []string
+	seen map[string]struct{}
 }
 
-// Proxy configures the HTTP listener and upstream target.
+// add appends a warning message.
+func (w *warnings) add(msg string) {
+	if w.seen == nil {
+		// Lazy initialization.
+		w.seen = make(map[string]struct{})
+	}
+	if _, ok := w.seen[msg]; ok {
+		// Skip duplicates warnings.
+		return
+	}
+	w.seen[msg] = struct{}{}
+	w.msgs = append(w.msgs, msg)
+}
+
+// Server configures the HTTP server and proxy.
+type Server struct {
+	Local
+	Proxy
+}
+
+// Local configures the local HTTP server.
+type Local struct {
+	// Addr is the address the server listens on.
+	Addr string
+}
+
+// Proxy configures communication with the upstream CouchDB server.
 type Proxy struct {
-	// Listen is the TCP address the server listens on, in the form 'host:port'
-	// or ':port' to listen on all interfaces.
-	Listen string
-	// Target is the CouchDB URL to which requests are proxied.
+	// Target is the URL of the CouchDB server to proxy requests to.
 	Target *url.URL
 	// Headers customizes the proxy headers sent to CouchDB.
 	Headers Headers
@@ -77,20 +100,12 @@ type Proxy struct {
 
 // Headers customizes the proxy headers forwarded to CouchDB.
 type Headers struct {
-	// Signer configures the signing of CouchDB proxy authentication tokens.
-	Signer Signer
-	// User is the proxy header name that carries the CouchDB user name.
-	User string
-	// Roles is the proxy header name that carries comma-separated roles.
-	Roles string
-	// Token is the proxy header name that carries the signed token proving
-	// the authenticity of the User header.
-	Token string
-	// Anonymous allows forwarding requests without an authenticated user.
-	// A request is considered anonymous if the deciding rule does not set
-	// a user or if the user expression yields an empty string. If false,
-	// such requests are denied with 401 Unauthorized.
-	Anonymous bool
+	// User  configures the proxy header that carries the CouchDB user name.
+	User UserHeader
+	// Roles configures the proxy header that carries CouchDB roles.
+	Roles RolesHeader
+	// Token configures the proxy header that carries the CouchDB token.
+	Token TokenHeader
 }
 
 // Signer configures the signing of CouchDB proxy authentication tokens.
@@ -103,24 +118,49 @@ type Signer struct {
 	Algorithm func() hash.Hash
 }
 
+// UserHeader configures the proxy header that carries the CouchDB user name.
+type UserHeader struct {
+	// Name is the proxy header name.
+	Name string
+	// Anonymous allows forwarding requests without an authenticated user.
+	// A request is considered anonymous if the deciding rule does not set
+	// a user or if the user expression yields an empty string. If false,
+	// such requests are denied with 401 Unauthorized.
+	Anonymous bool
+}
+
+// RolesHeader configures the proxy header that carries CouchDB roles.
+type RolesHeader struct {
+	// Name is the proxy header name.
+	Name string
+	// Default specifies the comma-separated list of default roles to assign to
+	// a user if the deciding rule does not set any roles.
+	Default string
+}
+
+// TokenHeader configures the proxy header that carries the CouchDB token.
+type TokenHeader struct {
+	// Name is the proxy header name.
+	Name string
+	Signer
+}
+
 // Remote configures periodic retrieval of a JWKS from a remote endpoint.
 type Remote struct {
-	// Endpoint is the HTTPS URL from which the JWKS is retrieved.
+	// Endpoint is the HTTP(S) URL from which the JWKS is retrieved.
 	// Required if no static key set is provided.
 	Endpoint string
 	// Interval is the poll interval measured in minutes.
 	Interval time.Duration
 }
 
-// Keys configures sources of JWK material used to verify token signatures.
-// Static and remote sources are merged when both are provided.
-type Keys struct {
-	// Static is a filesystem path to a JWKS document.
-	// If not provided, a remote endpoint must be configured.
-	Static string
-	// Remote specifies a JWKS endpoint to fetch and refresh keys from.
-	// If not provided, a static JWKS file must be configured.
-	Remote Remote
+// Guard configures the authentication and authorization of incoming requests.
+type Guard struct {
+	// Token configures how incoming bearer tokens are validated.
+	Token Token
+	// Rules defines ordered authorization rules. The first matching rule
+	// decides the outcome. At least one rule is required.
+	Rules []Rule
 }
 
 // Token configures the validation of access tokens.
@@ -142,6 +182,17 @@ type Token struct {
 	Clock jwt.Clock
 }
 
+// Keys configures sources of JWK material used to verify token signatures.
+// Static and remote sources are merged when both are provided.
+type Keys struct {
+	// Static is a filesystem path to a JWKS document.
+	// If not provided, a remote endpoint must be configured.
+	Static string
+	// Remote specifies a JWKS endpoint to fetch and refresh keys from.
+	// If not provided, a static JWKS file must be configured.
+	Remote Remote
+}
+
 // Rule represents a single, uncompiled authorization rule loaded from config.
 // Expressions in When, User, and Roles are plain strings that must be compiled
 // before use.
@@ -156,7 +207,7 @@ type Rule struct {
 	// User is an optional expression that determines the CouchDB user name to
 	// authenticate as. It is empty when Deny is true. If the expression
 	// evaluates to an empty string, the request is forwarded anonymously,
-	// provided that Headers.Anonymous is true.
+	// provided that the user header configuration allows anonymous requests.
 	User string
 	// Roles is an optional expression that specifies CouchDB roles for
 	// authentication. It is empty when Deny is true. If specified, the
@@ -166,69 +217,122 @@ type Rule struct {
 
 // config is the wire representation of Config.
 type config struct {
-	Proxy proxy  `yaml:"proxy"`
+	Local local `yaml:"local"`
+	Proxy proxy `yaml:"proxy"`
+	Guard guard `yaml:"guard"`
+}
+
+// validate derives the runtime representation of config.
+func (c config) validate(w *warnings) (Config, error) {
+	local, err := c.Local.validate(w)
+	if err != nil {
+		return Config{}, fmt.Errorf("local.%w", err)
+	}
+	proxy, err := c.Proxy.validate(w)
+	if err != nil {
+		return Config{}, fmt.Errorf("proxy.%w", err)
+	}
+	guard, err := c.Guard.validate(w)
+	if err != nil {
+		return Config{}, fmt.Errorf("guard.%w", err)
+	}
+	server := Server{
+		Local: local,
+		Proxy: proxy,
+	}
+	return Config{
+		Guard:  guard,
+		Server: server,
+	}, nil
+}
+
+// guard is the wire representation of Guard.
+type guard struct {
 	Token token  `yaml:"token"`
 	Rules []rule `yaml:"rules"`
 }
 
-// validate derives the runtime representation of config.
-func (c config) validate() (Config, error) {
-	proxy, err := c.Proxy.validate()
+// validate derives the runtime representation of guard.
+func (g guard) validate(w *warnings) (Guard, error) {
+	token, err := g.Token.validate(w)
 	if err != nil {
-		return Config{}, fmt.Errorf("proxy.%w", err)
+		return Guard{}, fmt.Errorf("token.%w", err)
 	}
-	token, err := c.Token.validate()
-	if err != nil {
-		return Config{}, fmt.Errorf("token.%w", err)
+	if len(g.Rules) == 0 {
+		return Guard{}, errors.New("rules: at least one rule must be specified")
 	}
-	if len(c.Rules) == 0 {
-		return Config{}, errors.New("rules: at least one rule must be specified")
-	}
-	rules := make([]Rule, len(c.Rules))
-	for i, r := range c.Rules {
-		rule, err := r.validate()
+	rules := make([]Rule, len(g.Rules))
+	for i, r := range g.Rules {
+		rule, err := r.validate(w)
 		if err != nil {
-			return Config{}, fmt.Errorf("rules[%d].%w", i, err)
+			return Guard{}, fmt.Errorf("rules[%d].%w", i, err)
 		}
 		rules[i] = rule
 	}
-	return Config{
-		Proxy: proxy,
+	return Guard{
 		Token: token,
 		Rules: rules,
 	}, nil
 }
 
+// local is the wire representation of Local.
+type local struct {
+	Host string `yaml:"host"`
+	Port int    `yaml:"port"`
+}
+
+// validate derives the runtime representation of local.
+func (l local) validate(_ *warnings) (Local, error) {
+	host := strings.TrimSpace(l.Host)
+	port := l.Port
+	if port < 0 || port > 65535 {
+		return Local{}, errors.New("port: out of range")
+	}
+	if port == 0 {
+		port = 8080
+	}
+	return Local{
+		Addr: net.JoinHostPort(host, strconv.Itoa(port)),
+	}, nil
+}
+
 // proxy is the wire representation of Proxy.
 type proxy struct {
-	Listen  string  `yaml:"listen"`
-	Target  string  `yaml:"target"`
+	Scheme  string  `yaml:"scheme"`
+	Host    string  `yaml:"host"`
+	Port    int     `yaml:"port"`
 	Headers headers `yaml:"headers"`
 }
 
 // validate derives the runtime representation of proxy.
-func (p proxy) validate() (Proxy, error) {
-	listen := strings.TrimSpace(p.Listen)
-	if listen == "" {
-		listen = ":8080"
+func (p proxy) validate(w *warnings) (Proxy, error) {
+	scheme := strings.TrimSpace(p.Scheme)
+	if scheme == "" {
+		scheme = "http"
 	}
-	target := strings.TrimSpace(p.Target)
-	if target == "" {
-		target = "http://localhost:5984"
+	host := strings.TrimSpace(p.Host)
+	if host == "" {
+		host = "localhost"
 	}
-	u, err := url.Parse(target)
+	port := p.Port
+	if port < 0 || port > 65535 {
+		return Proxy{}, errors.New("port: out of range")
+	}
+	if port == 0 {
+		port = 8080
+	}
+	u, err := url.Parse(fmt.Sprintf("%s://%s:%d", scheme, host, port))
 	if err != nil {
-		return Proxy{}, fmt.Errorf("target: invalid url: %w", err)
+		return Proxy{}, fmt.Errorf("scheme+host+port: invalid url: %w", err)
 	}
 	if u.Scheme != "http" && u.Scheme != "https" {
-		return Proxy{}, fmt.Errorf("target: illegal url scheme %q", u.Scheme)
+		return Proxy{}, fmt.Errorf("scheme: must be 'http' or 'https'")
 	}
-	headers, err := p.Headers.validate()
+	headers, err := p.Headers.validate(w)
 	if err != nil {
 		return Proxy{}, fmt.Errorf("headers.%w", err)
 	}
 	return Proxy{
-		Listen:  listen,
 		Target:  u,
 		Headers: headers,
 	}, nil
@@ -236,43 +340,100 @@ func (p proxy) validate() (Proxy, error) {
 
 // headers is the wire representation of Headers.
 type headers struct {
-	Signer    signer `yaml:"signer"`
-	User      string `yaml:"user"`
-	Roles     string `yaml:"roles"`
-	Token     string `yaml:"token"`
-	Anonymous bool   `yaml:"anonymous"`
+	User  userHeader  `yaml:"user"`
+	Roles rolesHeader `yaml:"roles"`
+	Token tokenHeader `yaml:"token"`
 }
 
 // validate derives the runtime representation of headers.
-func (h headers) validate() (Headers, error) {
-	signer, err := h.Signer.validate()
+func (h headers) validate(w *warnings) (Headers, error) {
+	user, err := h.User.validate(w)
 	if err != nil {
-		return Headers{}, fmt.Errorf("signer.%w", err)
+		return Headers{}, fmt.Errorf("user.%w", err)
 	}
-	user := strings.TrimSpace(h.User)
-	if user == "" {
-		user = "X-Auth-CouchDB-UserName"
-	} else {
-		user = http.CanonicalHeaderKey(user)
+	roles, err := h.Roles.validate(w)
+	if err != nil {
+		return Headers{}, fmt.Errorf("roles.%w", err)
 	}
-	roles := strings.TrimSpace(h.Roles)
-	if roles == "" {
-		roles = "X-Auth-CouchDB-Roles"
-	} else {
-		roles = http.CanonicalHeaderKey(roles)
-	}
-	token := strings.TrimSpace(h.Token)
-	if token == "" {
-		token = "X-Auth-CouchDB-Token"
-	} else {
-		token = http.CanonicalHeaderKey(token)
+	token, err := h.Token.validate(w)
+	if err != nil {
+		return Headers{}, fmt.Errorf("token.%w", err)
 	}
 	return Headers{
-		Signer:    signer,
-		User:      user,
-		Roles:     roles,
-		Token:     token,
-		Anonymous: h.Anonymous,
+		User:  user,
+		Roles: roles,
+		Token: token,
+	}, nil
+}
+
+// userHeader is the wire representation of UserHeader.
+type userHeader struct {
+	Name      string `yaml:"name"`
+	Anonymous bool   `yaml:"anonymous"`
+}
+
+// validate derives the runtime representation of userHeader.
+func (u userHeader) validate(_ *warnings) (UserHeader, error) {
+	name := strings.TrimSpace(u.Name)
+	if name == "" {
+		name = "X-Auth-CouchDB-UserName"
+	} else {
+		name = http.CanonicalHeaderKey(name)
+	}
+	return UserHeader{
+		Name:      name,
+		Anonymous: u.Anonymous,
+	}, nil
+}
+
+// rolesHeader is the wire representation of RolesHeader.
+type rolesHeader struct {
+	Name    string   `yaml:"name"`
+	Default []string `yaml:"default"`
+}
+
+// validate derives the runtime representation of rolesHeader.
+func (r rolesHeader) validate(_ *warnings) (RolesHeader, error) {
+	name := strings.TrimSpace(r.Name)
+	if name == "" {
+		name = "X-Auth-CouchDB-Roles"
+	} else {
+		name = http.CanonicalHeaderKey(name)
+	}
+	defs := make([]string, 0, len(r.Default))
+	for _, r := range r.Default {
+		r = strings.TrimSpace(r)
+		if r != "" {
+			defs = append(defs, r)
+		}
+	}
+	return RolesHeader{
+		Name:    name,
+		Default: strings.Join(defs, ","),
+	}, nil
+}
+
+// tokenHeader is the wire representation of TokenHeader.
+type tokenHeader struct {
+	Name string `yaml:"name"`
+	signer
+}
+
+// validate derives the runtime representation of tokenHeader.
+func (t tokenHeader) validate(w *warnings) (TokenHeader, error) {
+	name := strings.TrimSpace(t.Name)
+	if name == "" {
+		name = "X-Auth-CouchDB-Token"
+	} else {
+		name = http.CanonicalHeaderKey(name)
+	}
+	signer, err := t.signer.validate(w)
+	if err != nil {
+		return TokenHeader{}, fmt.Errorf("signer.%w", err)
+	}
+	return TokenHeader{
+		Name:   name,
+		Signer: signer,
 	}, nil
 }
 
@@ -283,11 +444,14 @@ type signer struct {
 }
 
 // validate derives the runtime representation of signer.
-func (s signer) validate() (Signer, error) {
+func (s signer) validate(w *warnings) (Signer, error) {
 	key := strings.TrimSpace(s.Secret)
 	if key == "" {
 		// Fall back to environment variable to facilitate secret management.
 		key = strings.TrimSpace(os.Getenv("VOUCH_SECRET"))
+	}
+	if key == "" {
+		w.add("proxy signing is disabled; this is not recommended for production")
 	}
 	var alg func() hash.Hash
 	switch name := strings.ToLower(strings.TrimSpace(s.Algorithm)); name {
@@ -295,6 +459,7 @@ func (s signer) validate() (Signer, error) {
 		alg = nil
 	case "sha":
 		alg = sha1.New
+		w.add("proxy signing uses sha1; prefer sha256 or stronger")
 	case "sha224":
 		alg = sha256.New224
 	case "sha256":
@@ -319,7 +484,7 @@ type remote struct {
 }
 
 // validate derives the runtime representation of remote.
-func (r remote) validate() (Remote, error) {
+func (r remote) validate(w *warnings) (Remote, error) {
 	endpoint := strings.TrimSpace(r.Endpoint)
 	if endpoint != "" {
 		u, err := url.Parse(endpoint)
@@ -328,6 +493,8 @@ func (r remote) validate() (Remote, error) {
 		}
 		if u.Scheme != "https" && u.Scheme != "http" {
 			return Remote{}, fmt.Errorf("endpoint: illegal url scheme %q", u.Scheme)
+		} else if u.Scheme != "https" {
+			w.add("jwks endpoint is not using https")
 		}
 	}
 	interval := r.Interval
@@ -349,9 +516,9 @@ type keys struct {
 }
 
 // validate derives the runtime representation of keys.
-func (k keys) validate() (Keys, error) {
+func (k keys) validate(w *warnings) (Keys, error) {
 	static := strings.TrimSpace(k.Static)
-	remote, err := k.Remote.validate()
+	remote, err := k.Remote.validate(w)
 	if err != nil {
 		return Keys{}, fmt.Errorf("remote.%w", err)
 	}
@@ -375,8 +542,8 @@ type token struct {
 }
 
 // validate derives the runtime representation of token.
-func (t token) validate() (Token, error) {
-	keys, err := t.Keys.validate()
+func (t token) validate(w *warnings) (Token, error) {
+	keys, err := t.Keys.validate(w)
 	if err != nil {
 		return Token{}, fmt.Errorf("keys.%w", err)
 	}
@@ -398,7 +565,7 @@ const (
 	modeDeny  = "deny"
 )
 
-// rule is is the wire representation of Rule.
+// rule is the wire representation of Rule.
 type rule struct {
 	Mode  string `yaml:"mode"`
 	When  string `yaml:"when"`
@@ -407,7 +574,7 @@ type rule struct {
 }
 
 // validate derives the runtime representation of rule.
-func (r rule) validate() (Rule, error) {
+func (r rule) validate(_ *warnings) (Rule, error) {
 	deny := false
 	switch strings.ToLower(strings.TrimSpace(r.Mode)) {
 	case modeAllow:
@@ -445,18 +612,25 @@ func (r rule) validate() (Rule, error) {
 
 // Load reads a YAML configuration file from path, decodes into wire types,
 // then validates and converts them into a fully populated Config instance.
-func Load(path string) (Config, error) {
+func Load(path string) (Config, []string, error) {
 	b, err := os.ReadFile(path)
 	if err != nil {
-		return Config{}, fmt.Errorf("read file %q: %w", path, err)
+		return Config{}, nil, fmt.Errorf("read file %q: %w", path, err)
 	}
 
 	var cfg config
 	dec := yaml.NewDecoder(bytes.NewReader(b))
 	dec.KnownFields(true)
 	if err := dec.Decode(&cfg); err != nil {
-		return Config{}, fmt.Errorf("parse yaml: %w", err)
+		return Config{}, nil, fmt.Errorf("parse yaml: %w", err)
 	}
 
-	return cfg.validate()
+	w := &warnings{}
+	c, err := cfg.validate(w)
+	// Provide warnings even when validation fails to aid diagnosis.
+	sort.Strings(w.msgs)
+	if err != nil {
+		return Config{}, w.msgs, fmt.Errorf("validation: %w", err)
+	}
+	return c, w.msgs, nil
 }

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -239,3 +239,18 @@ guard:
 	assert.Equal(t, "X-Custom-Roles", h.Roles.Name)
 	assert.Equal(t, "X-Custom-Token", h.Token.Name)
 }
+
+func TestLoadAcceptsOptions(t *testing.T) {
+	yml := `
+guard:
+  token:
+    keys:
+      remote:
+        endpoint: https://example.com/jwks
+  rules:
+    - mode: allow
+      when: "true"
+`
+	_, _, err := Load(writeConfig(t, yml), WithVersion("1.2.3"))
+	require.NoError(t, err)
+}

--- a/internal/logger/logger.go
+++ b/internal/logger/logger.go
@@ -19,7 +19,6 @@ import (
 	"log/slog"
 	"os"
 	"strings"
-	"time"
 )
 
 // New returns a structured JSON logger configured at the requested
@@ -54,15 +53,6 @@ func New(v string) *slog.Logger {
 		os.Stdout,
 		&slog.HandlerOptions{
 			Level: level,
-			ReplaceAttr: func(groups []string, attr slog.Attr) slog.Attr {
-				// Truncate the time attribute to whole seconds.
-				if attr.Key == slog.TimeKey {
-					if t, ok := attr.Value.Any().(time.Time); ok {
-						attr.Value = slog.TimeValue(t.Truncate(time.Second))
-					}
-				}
-				return attr
-			},
 		},
 	))
 }


### PR DESCRIPTION
- Grouped settings to better reflect application components.
- Enabled the configuration of default roles for new users.
- Vouch now adds a custom `User-Agent` header to outbound JWKS requests.